### PR TITLE
Add extensive validation tests for create order

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,12 +28,13 @@ func main() {
 	repo := ord.NewPostgresRepository(db)
 	svc := ord.NewService(repo)
 	ctrl := ord.NewController(svc)
-	authSvc := auth.NewService(secret)
-	authCtrl := auth.NewController(authSvc)
+
 	secret := []byte(os.Getenv("JWT_SECRET"))
 	if len(secret) == 0 {
 		secret = []byte("secret")
 	}
+	authSvc := auth.NewService(secret)
+	authCtrl := auth.NewController(authSvc)
 
 	// log to file
 	f, err := os.OpenFile("server.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)

--- a/internal/order/controller_test.go
+++ b/internal/order/controller_test.go
@@ -1,0 +1,40 @@
+package order
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCreateOrderValidation(t *testing.T) {
+	repo := newMock()
+	svc := NewService(repo)
+	ctrl := NewController(svc)
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"empty body", `{}`, http.StatusUnprocessableEntity},
+		{"missing receiver", `{"account_id":"a","seller_id":"s","delivery_id":"d","basket_id":"b"}`, http.StatusUnprocessableEntity},
+		{"missing account", `{"receiver_id":"r","seller_id":"s","delivery_id":"d","basket_id":"b"}`, http.StatusUnprocessableEntity},
+		{"missing seller", `{"receiver_id":"r","account_id":"a","delivery_id":"d","basket_id":"b"}`, http.StatusUnprocessableEntity},
+		{"missing delivery", `{"receiver_id":"r","account_id":"a","seller_id":"s","basket_id":"b"}`, http.StatusUnprocessableEntity},
+		{"missing basket", `{"receiver_id":"r","account_id":"a","seller_id":"s","delivery_id":"d"}`, http.StatusUnprocessableEntity},
+		{"invalid json", `{"receiver_id":`, http.StatusBadRequest},
+		{"valid", `{"receiver_id":"r","account_id":"a","seller_id":"s","delivery_id":"d","basket_id":"b"}`, http.StatusCreated},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/orders", strings.NewReader(tc.body))
+			w := httptest.NewRecorder()
+			ctrl.createOrder(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("want %d got %d body: %s", tc.want, w.Code, w.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- expand controller unit tests with table-driven cases for missing fields, invalid JSON, and successful creation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68406b94e62483249388aa4696d9ef9b