### PR TITLE
Implement payment service and order status tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ day automatically. Logs are written to `delivery.log`.
 
 API documentation is available in `docs/delivery-swagger.yaml`.
 
+### Payment Service
+
+Payments are recorded through a separate microservice. Run the migration and start the service:
+
+```bash
+psql -h localhost -U postgres -d order -f internal/payment/migrations/001_create_payments.sql
+go run ./cmd/payment
+```
+
+See `docs/payment.md` for more details. Successful payments automatically set the related order status to `paid` and logs are written to `payment.log`.
+
 ## API
 
 All endpoints require a valid JWT in the `Authorization: Bearer <token>` header.

--- a/cmd/payment/main.go
+++ b/cmd/payment/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/jmoiron/sqlx"
+	"github.com/joho/godotenv"
+	_ "github.com/lib/pq"
+	ord "order/internal/order"
+	"order/internal/payment"
+)
+
+func main() {
+	_ = godotenv.Load()
+	dsn := os.Getenv("DB_DSN")
+	if dsn == "" {
+		log.Fatal("DB_DSN env not set")
+	}
+	db, err := sqlx.Connect("postgres", dsn)
+	if err != nil {
+		log.Fatalf("db connect: %v", err)
+	}
+
+	payRepo := payment.NewPostgresRepository(db)
+	orderRepo := ord.NewPostgresRepository(db)
+	svc := payment.NewService(payRepo, orderRepo)
+	ctrl := payment.NewController(svc)
+
+	f, err := os.OpenFile("payment.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		log.Fatalf("log file: %v", err)
+	}
+	log.SetOutput(io.MultiWriter(os.Stdout, f))
+
+	r := mux.NewRouter()
+	ctrl.RegisterRoutes(r)
+
+	log.Println("payment service listening on :8091")
+	log.Fatal(http.ListenAndServe(":8091", r))
+}

--- a/docs/payment.md
+++ b/docs/payment.md
@@ -1,0 +1,21 @@
+# Payment Service
+
+This microservice records payments for orders. When a payment is accepted the related order status is automatically changed to `paid`.
+
+## Environment
+- `DB_DSN` – PostgreSQL connection string
+
+## Endpoints
+- `POST /payments` – register a payment
+- `GET /payments/{id}` – get payment details
+
+Run migrations before starting the service:
+```bash
+psql -h localhost -U postgres -d order -f internal/payment/migrations/001_create_payments.sql
+```
+
+Start the service:
+```bash
+go run ./cmd/payment
+```
+Logs are written to `payment.log`.

--- a/internal/order/dto.go
+++ b/internal/order/dto.go
@@ -4,20 +4,22 @@ package order
 // Validation tags ensure data integrity
 
 type OrderCreateDTO struct {
-    ReceiverID string `json:"receiver_id" validate:"required"`
-    AccountID  string `json:"account_id" validate:"required"`
-    SellerID   string `json:"seller_id" validate:"required"`
-    DeliveryID string `json:"delivery_id" validate:"required"`
-    BasketID   string `json:"basket_id" validate:"required"`
+	ReceiverID string `json:"receiver_id" validate:"required"`
+	AccountID  string `json:"account_id" validate:"required"`
+	SellerID   string `json:"seller_id" validate:"required"`
+	DeliveryID string `json:"delivery_id" validate:"required"`
+	BasketID   string `json:"basket_id" validate:"required"`
+	Status     string `json:"status"`
 }
 
 // OrderUpdateDTO defines input for updating an order
 // All fields are optional for PATCH
 
 type OrderUpdateDTO struct {
-    ReceiverID *string `json:"receiver_id"`
-    AccountID  *string `json:"account_id"`
-    SellerID   *string `json:"seller_id"`
-    DeliveryID *string `json:"delivery_id"`
-    BasketID   *string `json:"basket_id"`
+	ReceiverID *string `json:"receiver_id"`
+	AccountID  *string `json:"account_id"`
+	SellerID   *string `json:"seller_id"`
+	DeliveryID *string `json:"delivery_id"`
+	BasketID   *string `json:"basket_id"`
+	Status     *string `json:"status"`
 }

--- a/internal/order/migrations/001_create_orders.sql
+++ b/internal/order/migrations/001_create_orders.sql
@@ -6,5 +6,6 @@ CREATE TABLE IF NOT EXISTS orders (
     account_id CHAR(26) NOT NULL,
     seller_id CHAR(26) NOT NULL,
     delivery_id CHAR(26) NOT NULL,
-    basket_id CHAR(26) NOT NULL
+    basket_id CHAR(26) NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'new'
 );

--- a/internal/order/model.go
+++ b/internal/order/model.go
@@ -6,12 +6,33 @@ import "time"
 // contains basic fields for an e-commerce order
 
 type Order struct {
-    ID         string    `db:"id" json:"id"`
-    CreatedAt  time.Time `db:"created_at" json:"created_at"`
-    UpdatedAt  time.Time `db:"updated_at" json:"updated_at"`
-    ReceiverID string    `db:"receiver_id" json:"receiver_id"`
-    AccountID  string    `db:"account_id" json:"account_id"`
-    SellerID   string    `db:"seller_id" json:"seller_id"`
-    DeliveryID string    `db:"delivery_id" json:"delivery_id"`
-    BasketID   string    `db:"basket_id" json:"basket_id"`
+	ID         string      `db:"id" json:"id"`
+	CreatedAt  time.Time   `db:"created_at" json:"created_at"`
+	UpdatedAt  time.Time   `db:"updated_at" json:"updated_at"`
+	ReceiverID string      `db:"receiver_id" json:"receiver_id"`
+	AccountID  string      `db:"account_id" json:"account_id"`
+	SellerID   string      `db:"seller_id" json:"seller_id"`
+	DeliveryID string      `db:"delivery_id" json:"delivery_id"`
+	BasketID   string      `db:"basket_id" json:"basket_id"`
+	Status     OrderStatus `db:"status" json:"status"`
 }
+
+// OrderStatus represents current lifecycle state of an order.
+type OrderStatus string
+
+const (
+	StatusNew              OrderStatus = "new"
+	StatusPendingPayment   OrderStatus = "pending_payment"
+	StatusPaid             OrderStatus = "paid"
+	StatusProcessing       OrderStatus = "processing"
+	StatusInAssembly       OrderStatus = "in_assembly"
+	StatusReadyForShipment OrderStatus = "ready_for_shipment"
+	StatusHandedOver       OrderStatus = "handed_over_for_delivery"
+	StatusInTransit        OrderStatus = "in_transit"
+	StatusDelivered        OrderStatus = "delivered"
+	StatusCompleted        OrderStatus = "completed"
+	StatusReturnRequested  OrderStatus = "return_requested"
+	StatusReturned         OrderStatus = "returned"
+	StatusCancelled        OrderStatus = "cancelled"
+	StatusRefunded         OrderStatus = "refunded"
+)

--- a/internal/order/repository.go
+++ b/internal/order/repository.go
@@ -21,8 +21,8 @@ type Repository interface {
 // PostgresRepository implements Repository using PostgreSQL
 
 const createQuery = `INSERT INTO orders
-    (id, created_at, updated_at, receiver_id, account_id, seller_id, delivery_id, basket_id)
-    VALUES (:id, :created_at, :updated_at, :receiver_id, :account_id, :seller_id, :delivery_id, :basket_id)`
+    (id, created_at, updated_at, receiver_id, account_id, seller_id, delivery_id, basket_id, status)
+    VALUES (:id, :created_at, :updated_at, :receiver_id, :account_id, :seller_id, :delivery_id, :basket_id, :status)`
 
 const getQuery = `SELECT * FROM orders WHERE id=$1`
 const listQuery = `SELECT * FROM orders`
@@ -33,7 +33,8 @@ const updateQuery = `UPDATE orders SET
     account_id=:account_id,
     seller_id=:seller_id,
     delivery_id=:delivery_id,
-    basket_id=:basket_id
+    basket_id=:basket_id,
+    status=:status
     WHERE id=:id`
 const deleteQuery = `DELETE FROM orders WHERE id=$1`
 

--- a/internal/order/service.go
+++ b/internal/order/service.go
@@ -16,6 +16,10 @@ type Service struct {
 func NewService(r Repository) *Service { return &Service{Repo: r} }
 
 func (s *Service) Create(ctx context.Context, dto OrderCreateDTO) (*Order, error) {
+	status := StatusNew
+	if dto.Status != "" {
+		status = OrderStatus(dto.Status)
+	}
 	o := &Order{
 		ID:         ulid.Make().String(),
 		CreatedAt:  time.Now(),
@@ -25,6 +29,7 @@ func (s *Service) Create(ctx context.Context, dto OrderCreateDTO) (*Order, error
 		SellerID:   dto.SellerID,
 		DeliveryID: dto.DeliveryID,
 		BasketID:   dto.BasketID,
+		Status:     status,
 	}
 	if err := s.Repo.Create(ctx, o); err != nil {
 		return nil, err
@@ -59,6 +64,9 @@ func (s *Service) Update(ctx context.Context, id string, dto OrderUpdateDTO) (*O
 	}
 	if dto.BasketID != nil {
 		o.BasketID = *dto.BasketID
+	}
+	if dto.Status != nil {
+		o.Status = OrderStatus(*dto.Status)
 	}
 	o.UpdatedAt = time.Now()
 	if err := s.Repo.Update(ctx, o); err != nil {

--- a/internal/order/service_test.go
+++ b/internal/order/service_test.go
@@ -41,4 +41,7 @@ func TestServiceCreateAndGet(t *testing.T) {
 	if got.ID != o.ID {
 		t.Fatalf("want %s got %s", o.ID, got.ID)
 	}
+	if got.Status != StatusNew {
+		t.Fatalf("want status %s got %s", StatusNew, got.Status)
+	}
 }

--- a/internal/payment/controller.go
+++ b/internal/payment/controller.go
@@ -1,0 +1,62 @@
+package payment
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/gorilla/mux"
+)
+
+// Controller exposes payment handlers.
+type Controller struct {
+	Service  *Service
+	Validate *validator.Validate
+}
+
+func NewController(s *Service) *Controller {
+	return &Controller{Service: s, Validate: validator.New()}
+}
+
+func (c *Controller) RegisterRoutes(r *mux.Router) {
+	r.HandleFunc("/payments", c.createPayment).Methods("POST")
+	r.HandleFunc("/payments/{id}", c.getPayment).Methods("GET")
+}
+
+func (c *Controller) createPayment(w http.ResponseWriter, r *http.Request) {
+	var dto CreateDTO
+	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := c.Validate.Struct(dto); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	p, err := c.Service.Accept(r.Context(), dto)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, http.StatusCreated, p)
+}
+
+func (c *Controller) getPayment(w http.ResponseWriter, r *http.Request) {
+	id := mux.Vars(r)["id"]
+	p, err := c.Service.Get(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if p == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, p)
+}
+
+func respondJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/internal/payment/dto.go
+++ b/internal/payment/dto.go
@@ -1,0 +1,7 @@
+package payment
+
+// CreateDTO describes a payment acceptance request.
+type CreateDTO struct {
+	OrderID string `json:"order_id" validate:"required"`
+	Amount  int64  `json:"amount" validate:"required"`
+}

--- a/internal/payment/migrations/001_create_payments.sql
+++ b/internal/payment/migrations/001_create_payments.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS payments (
+    id CHAR(26) PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    order_id CHAR(26) NOT NULL,
+    amount BIGINT NOT NULL,
+    status VARCHAR(50) NOT NULL
+);

--- a/internal/payment/model.go
+++ b/internal/payment/model.go
@@ -1,0 +1,13 @@
+package payment
+
+import "time"
+
+// Payment represents a received payment for an order.
+type Payment struct {
+	ID        string    `db:"id" json:"id"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+	OrderID   string    `db:"order_id" json:"order_id"`
+	Amount    int64     `db:"amount" json:"amount"`
+	Status    string    `db:"status" json:"status"`
+}

--- a/internal/payment/repository.go
+++ b/internal/payment/repository.go
@@ -1,0 +1,40 @@
+package payment
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// Repository defines persistence layer for payments.
+type Repository interface {
+	Create(ctx context.Context, p *Payment) error
+	GetByID(ctx context.Context, id string) (*Payment, error)
+}
+
+const createQuery = `INSERT INTO payments
+    (id, created_at, updated_at, order_id, amount, status)
+    VALUES (:id, :created_at, :updated_at, :order_id, :amount, :status)`
+
+const getQuery = `SELECT * FROM payments WHERE id=$1`
+
+type PostgresRepository struct{ DB *sqlx.DB }
+
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository { return &PostgresRepository{DB: db} }
+
+func (r *PostgresRepository) Create(ctx context.Context, p *Payment) error {
+	_, err := r.DB.NamedExecContext(ctx, createQuery, p)
+	return err
+}
+
+func (r *PostgresRepository) GetByID(ctx context.Context, id string) (*Payment, error) {
+	var p Payment
+	if err := r.DB.GetContext(ctx, &p, getQuery, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &p, nil
+}

--- a/internal/payment/service.go
+++ b/internal/payment/service.go
@@ -1,0 +1,45 @@
+package payment
+
+import (
+	"context"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	ord "order/internal/order"
+)
+
+// Service implements payment acceptance logic.
+type Service struct {
+	Repo      Repository
+	OrderRepo ord.Repository
+}
+
+func NewService(r Repository, or ord.Repository) *Service {
+	return &Service{Repo: r, OrderRepo: or}
+}
+
+func (s *Service) Accept(ctx context.Context, dto CreateDTO) (*Payment, error) {
+	p := &Payment{
+		ID:        ulid.Make().String(),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		OrderID:   dto.OrderID,
+		Amount:    dto.Amount,
+		Status:    "paid",
+	}
+	if err := s.Repo.Create(ctx, p); err != nil {
+		return nil, err
+	}
+	if o, err := s.OrderRepo.GetByID(ctx, dto.OrderID); err == nil && o != nil {
+		o.Status = ord.StatusPaid
+		o.UpdatedAt = time.Now()
+		if err := s.OrderRepo.Update(ctx, o); err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
+func (s *Service) Get(ctx context.Context, id string) (*Payment, error) {
+	return s.Repo.GetByID(ctx, id)
+}

--- a/internal/payment/service_test.go
+++ b/internal/payment/service_test.go
@@ -1,0 +1,61 @@
+package payment
+
+import (
+	"context"
+	ord "order/internal/order"
+	"testing"
+)
+
+type mockOrderRepo struct{ store map[string]*ord.Order }
+
+func newOrderMock() *mockOrderRepo { return &mockOrderRepo{store: make(map[string]*ord.Order)} }
+
+func (m *mockOrderRepo) Create(ctx context.Context, o *ord.Order) error {
+	m.store[o.ID] = o
+	return nil
+}
+func (m *mockOrderRepo) GetByID(ctx context.Context, id string) (*ord.Order, error) {
+	if o, ok := m.store[id]; ok {
+		return o, nil
+	}
+	return nil, nil
+}
+func (m *mockOrderRepo) List(ctx context.Context, deliveryID string) ([]ord.Order, error) {
+	return nil, nil
+}
+func (m *mockOrderRepo) Update(ctx context.Context, o *ord.Order) error {
+	m.store[o.ID] = o
+	return nil
+}
+func (m *mockOrderRepo) Delete(ctx context.Context, id string) error { delete(m.store, id); return nil }
+
+type mockRepo struct{ store map[string]*Payment }
+
+func newMock() *mockRepo { return &mockRepo{store: make(map[string]*Payment)} }
+
+func (m *mockRepo) Create(ctx context.Context, p *Payment) error { m.store[p.ID] = p; return nil }
+func (m *mockRepo) GetByID(ctx context.Context, id string) (*Payment, error) {
+	if p, ok := m.store[id]; ok {
+		return p, nil
+	}
+	return nil, nil
+}
+
+func TestAcceptPayment(t *testing.T) {
+	pRepo := newMock()
+	oRepo := newOrderMock()
+	order := &ord.Order{ID: "1", ReceiverID: "r", AccountID: "a", SellerID: "s", DeliveryID: "d", BasketID: "b", Status: ord.StatusNew}
+	oRepo.Create(context.Background(), order)
+
+	svc := NewService(pRepo, oRepo)
+	pay, err := svc.Accept(context.Background(), CreateDTO{OrderID: "1", Amount: 100})
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	if pay.Status != "paid" {
+		t.Fatalf("want paid got %s", pay.Status)
+	}
+	if oRepo.store["1"].Status != ord.StatusPaid {
+		t.Fatalf("order not updated")
+	}
+}


### PR DESCRIPTION
## Summary
- implement extensive order status tracking
- create payment service with API endpoints and migrations
- update README with payment service instructions
- document payment service
- adjust order database schema and logic
- add tests for payments and new order status

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844610977e883248416348d1d55afd1