### PR TITLE
Implement basic RBAC with user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This service implements a simple but scalable order API using Domain Driven Design (DDD). Orders are stored in PostgreSQL and authenticated via JWT.
 
+OpenAPI specifications for all services are located in the `docs` directory.
+
 ## Requirements
 
 - Go 1.24+
@@ -19,6 +21,9 @@ Run database migration:
 
 ```bash
 psql -h localhost -U postgres -d order -f internal/order/migrations/001_create_orders.sql
+
+# create users table
+psql -h localhost -U postgres -d order -f internal/user/migrations/001_create_users.sql
 ```
 
 Configure environment variables in a `.env` file (example values shown):
@@ -56,6 +61,8 @@ day automatically. Logs are written to `delivery.log`.
 
 API documentation is available in `docs/delivery-swagger.yaml`.
 
+The main order API is documented in `docs/order-swagger.yaml`.
+
 ### Payment Service
 
 Payments are recorded through a separate microservice. Run the migration and start the service:
@@ -66,6 +73,7 @@ go run ./cmd/payment
 ```
 
 See `docs/payment.md` for more details. Successful payments automatically set the related order status to `paid` and logs are written to `payment.log`.
+API documentation for the payment service is available in `docs/payment-swagger.yaml`.
 
 ## API
 
@@ -82,11 +90,11 @@ Validation errors return HTTP `422`. Missing or invalid tokens return `401`. Whe
 
 ### Authentication
 
-Obtain a JWT token using the static credentials `admin` / `password`:
+Obtain a JWT token using credentials stored in the `users` table (create users via `/users`):
 
 ```bash
 curl -X POST http://localhost:8080/auth/login \
-  -d '{"username":"admin","password":"password"}' \
+  -d '{"username":"<user>","password":"<pass>"}' \
   -H 'Content-Type: application/json'
 ```
 

--- a/docs/order-swagger.yaml
+++ b/docs/order-swagger.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  title: Order Service API
+  version: 1.0.0
+paths:
+  /auth/login:
+    post:
+      summary: Obtain JWT token
+      responses:
+        '200': {description: OK}
+  /auth/refresh:
+    post:
+      summary: Refresh JWT token
+      responses:
+        '200': {description: OK}
+  /users:
+    post:
+      summary: Create user
+      responses:
+        '201': {description: Created}
+  /orders:
+    get:
+      summary: List orders
+      responses:
+        '200': {description: OK}
+    post:
+      summary: Create order
+      responses:
+        '201': {description: Created}
+  /orders/{id}:
+    get:
+      summary: Get order
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: {type: string}
+      responses:
+        '200': {description: OK}
+    patch:
+      summary: Update order
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: {type: string}
+      responses:
+        '200': {description: OK}
+    delete:
+      summary: Delete order
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: {type: string}
+      responses:
+        '204': {description: No content}
+  /metrics:
+    get:
+      summary: Service metrics
+      responses:
+        '200': {description: OK}

--- a/docs/payment-swagger.yaml
+++ b/docs/payment-swagger.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.0
+info:
+  title: Payment Service API
+  version: 1.0.0
+paths:
+  /payments:
+    post:
+      summary: Register payment
+      responses:
+        '201': {description: Created}
+  /payments/{id}:
+    get:
+      summary: Get payment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: {type: string}
+      responses:
+        '200': {description: OK}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,30 +1,61 @@
 package auth
 
 import (
-    "net/http"
-    "strings"
+	"context"
+	"net/http"
+	"strings"
 
-    "github.com/golang-jwt/jwt/v5"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // Middleware validates JWT token from Authorization header
 func Middleware(secret []byte) func(http.Handler) http.Handler {
-    return func(next http.Handler) http.Handler {
-        return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-            auth := r.Header.Get("Authorization")
-            if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
-                http.Error(w, "unauthorized", http.StatusUnauthorized)
-                return
-            }
-            tokenStr := strings.TrimPrefix(auth, "Bearer ")
-            _, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
-                return secret, nil
-            })
-            if err != nil {
-                http.Error(w, "unauthorized", http.StatusUnauthorized)
-                return
-            }
-            next.ServeHTTP(w, r)
-        })
-    }
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			tokenStr := strings.TrimPrefix(auth, "Bearer ")
+			claims := jwt.MapClaims{}
+			_, err := jwt.ParseWithClaims(tokenStr, claims, func(t *jwt.Token) (interface{}, error) {
+				return secret, nil
+			})
+			if err != nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			rolesIface, _ := claims["roles"].([]interface{})
+			roles := make([]string, 0, len(rolesIface))
+			for _, v := range rolesIface {
+				if s, ok := v.(string); ok {
+					roles = append(roles, s)
+				}
+			}
+			sub, _ := claims["sub"].(string)
+			ctx := context.WithValue(r.Context(), ctxUserID{}, sub)
+			ctx = context.WithValue(ctx, ctxRoles{}, roles)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+type ctxUserID struct{}
+type ctxRoles struct{}
+
+// UserIDFromContext returns authenticated user id from context.
+func UserIDFromContext(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxUserID{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// RolesFromContext returns role list from context.
+func RolesFromContext(ctx context.Context) []string {
+	if v, ok := ctx.Value(ctxRoles{}).([]string); ok {
+		return v
+	}
+	return nil
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestGenerateAndRefresh(t *testing.T) {
 	svc := NewService([]byte("test"))
-	tok, refresh, err := svc.GenerateToken("user")
+	tok, refresh, err := svc.GenerateToken("user", []string{"admin"})
 	if err != nil || tok == "" || refresh == "" {
 		t.Fatalf("generate: %v", err)
 	}

--- a/internal/order/rbac.go
+++ b/internal/order/rbac.go
@@ -1,0 +1,44 @@
+package order
+
+import (
+	"context"
+
+	"order/internal/auth"
+	"order/internal/user"
+)
+
+func hasRole(roles []string, r user.Role) bool {
+	for _, v := range roles {
+		if v == string(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func canView(ctx context.Context, o *Order) bool {
+	roles := auth.RolesFromContext(ctx)
+	uid := auth.UserIDFromContext(ctx)
+	if hasRole(roles, user.RoleAdmin) || hasRole(roles, user.RoleSupportManager) || hasRole(roles, user.RoleAuditor) {
+		return true
+	}
+	if hasRole(roles, user.RoleSeller) && o.SellerID == uid {
+		return true
+	}
+	if hasRole(roles, user.RoleCustomer) && o.AccountID == uid {
+		return true
+	}
+	return false
+}
+
+func canEdit(ctx context.Context, o *Order) bool {
+	roles := auth.RolesFromContext(ctx)
+	uid := auth.UserIDFromContext(ctx)
+	if hasRole(roles, user.RoleAdmin) || hasRole(roles, user.RoleSupportManager) {
+		return true
+	}
+	if hasRole(roles, user.RoleSeller) && o.SellerID == uid {
+		return true
+	}
+	return false
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,10 +8,11 @@ import (
 	"order/internal/auth"
 	"order/internal/metrics"
 	ord "order/internal/order"
+	usr "order/internal/user"
 )
 
 // New sets up application routes with middleware
-func New(orderCtrl *ord.Controller, secret []byte, authCtrl *auth.Controller) http.Handler {
+func New(orderCtrl *ord.Controller, secret []byte, authCtrl *auth.Controller, userCtrl *usr.Controller) http.Handler {
 	r := mux.NewRouter()
 
 	r.Use(metrics.Middleware)
@@ -25,6 +26,7 @@ func New(orderCtrl *ord.Controller, secret []byte, authCtrl *auth.Controller) ht
 	api := r.PathPrefix("").Subrouter()
 	api.Use(auth.Middleware(secret))
 	orderCtrl.RegisterRoutes(api)
+	api.HandleFunc("/users", userCtrl.CreateUser).Methods("POST")
 
 	return r
 }

--- a/internal/user/controller.go
+++ b/internal/user/controller.go
@@ -1,0 +1,41 @@
+package user
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// Controller exposes handlers for managing users.
+type Controller struct {
+	Service  *Service
+	Validate *validator.Validate
+}
+
+func NewController(s *Service) *Controller { return &Controller{Service: s, Validate: validator.New()} }
+
+// CreateUser registers a new user.
+func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request) {
+	var dto UserCreateDTO
+	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := c.Validate.Struct(dto); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	u, err := c.Service.Create(r.Context(), dto)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, http.StatusCreated, u)
+}
+
+func respondJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/internal/user/dto.go
+++ b/internal/user/dto.go
@@ -1,0 +1,9 @@
+package user
+
+type UserCreateDTO struct {
+	Username  string  `json:"username" validate:"required"`
+	Password  string  `json:"password" validate:"required"`
+	Roles     []Role  `json:"roles" validate:"required"`
+	SellerID  *string `json:"seller_id,omitempty"`
+	AccountID *string `json:"account_id,omitempty"`
+}

--- a/internal/user/migrations/001_create_users.sql
+++ b/internal/user/migrations/001_create_users.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS users (
+    id CHAR(26) PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    username VARCHAR(100) UNIQUE NOT NULL,
+    password VARCHAR(100) NOT NULL,
+    roles TEXT[] NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    seller_id CHAR(26),
+    account_id CHAR(26)
+);

--- a/internal/user/model.go
+++ b/internal/user/model.go
@@ -1,0 +1,31 @@
+package user
+
+import "time"
+
+// Role defines access level of a user
+//
+// Additional roles may be added to support fine grained RBAC.
+type Role string
+
+const (
+	RoleAdmin            Role = "admin"
+	RoleSupportManager   Role = "support_manager"
+	RoleSeller           Role = "seller"
+	RoleCustomer         Role = "customer"
+	RoleLogisticsManager Role = "logistics_manager"
+	RolePaymentManager   Role = "payment_manager"
+	RoleAuditor          Role = "auditor"
+)
+
+// User represents application user with login credentials and profile link.
+type User struct {
+	ID        string    `db:"id" json:"id"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+	Username  string    `db:"username" json:"username"`
+	Password  string    `db:"password" json:"-"`
+	Roles     []Role    `db:"roles" json:"roles"`
+	Active    bool      `db:"active" json:"active"`
+	SellerID  *string   `db:"seller_id" json:"seller_id,omitempty"`
+	AccountID *string   `db:"account_id" json:"account_id,omitempty"`
+}

--- a/internal/user/repository.go
+++ b/internal/user/repository.go
@@ -1,0 +1,60 @@
+package user
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// Repository defines persistence behavior for users
+
+type Repository interface {
+	Create(ctx context.Context, u *User) error
+	GetByUsername(ctx context.Context, username string) (*User, error)
+	Update(ctx context.Context, u *User) error
+}
+
+// PostgresRepository implements Repository using PostgreSQL
+
+const createQuery = `INSERT INTO users
+    (id, created_at, updated_at, username, password, roles, active, seller_id, account_id)
+    VALUES (:id, :created_at, :updated_at, :username, :password, :roles, :active, :seller_id, :account_id)`
+
+const getQuery = `SELECT * FROM users WHERE username=$1 AND active=true`
+
+const updateQuery = `UPDATE users SET
+    updated_at=:updated_at,
+    password=:password,
+    roles=:roles,
+    active=:active,
+    seller_id=:seller_id,
+    account_id=:account_id
+    WHERE id=:id`
+
+type PostgresRepository struct {
+	DB *sqlx.DB
+}
+
+func NewPostgresRepository(db *sqlx.DB) *PostgresRepository { return &PostgresRepository{DB: db} }
+
+func (r *PostgresRepository) Create(ctx context.Context, u *User) error {
+	_, err := r.DB.NamedExecContext(ctx, createQuery, u)
+	return err
+}
+
+func (r *PostgresRepository) GetByUsername(ctx context.Context, username string) (*User, error) {
+	var u User
+	if err := r.DB.GetContext(ctx, &u, getQuery, username); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &u, nil
+}
+
+func (r *PostgresRepository) Update(ctx context.Context, u *User) error {
+	_, err := r.DB.NamedExecContext(ctx, updateQuery, u)
+	return err
+}

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -1,0 +1,43 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// Service encapsulates business logic around users.
+type Service struct {
+	Repo Repository
+}
+
+func NewService(r Repository) *Service { return &Service{Repo: r} }
+
+func (s *Service) Create(ctx context.Context, dto UserCreateDTO) (*User, error) {
+	u := &User{
+		ID:        ulid.Make().String(),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Username:  dto.Username,
+		Password:  dto.Password,
+		Roles:     dto.Roles,
+		Active:    true,
+		SellerID:  dto.SellerID,
+		AccountID: dto.AccountID,
+	}
+	if err := s.Repo.Create(ctx, u); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+// Authenticate verifies credentials and returns the user if valid.
+func (s *Service) Authenticate(ctx context.Context, username, password string) (*User, error) {
+	u, err := s.Repo.GetByUsername(ctx, username)
+	if err != nil || u == nil || !u.Active || u.Password != password {
+		return nil, errors.New("invalid credentials")
+	}
+	return u, nil
+}


### PR DESCRIPTION
## Summary
- add new user domain with CRUD and Postgres repository
- issue JWT tokens with role claims and expose helper functions
- enforce RBAC rules on order operations
- create `/users` endpoint and wire services in server startup
- update docs and tests
- add Swagger docs for all services

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68473edc44d08324973bb5ddeceac4f1