### PR TITLE
Implement allowed-endpoints endpoint

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 	"order/internal/basket"
 	"order/internal/item"
 	ord "order/internal/order"
+	"order/internal/rbac"
 	"order/internal/router"
 	usr "order/internal/user"
 )
@@ -53,16 +54,13 @@ func main() {
 	userSvc := usr.NewService(userRepo)
 	userCtrl := usr.NewController(userSvc)
 
-	userRepo := usr.NewPostgresRepository(db)
-	userSvc := usr.NewService(userRepo)
-	userCtrl := usr.NewController(userSvc)
-
 	secret := []byte(os.Getenv("JWT_SECRET"))
 	if len(secret) == 0 {
 		secret = []byte("secret")
 	}
 	authSvc := auth.NewService(secret)
 	authCtrl := auth.NewController(authSvc, userSvc)
+	rbacCtrl := rbac.NewController()
 
 	// log to file
 	f, err := os.OpenFile("server.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
@@ -71,7 +69,7 @@ func main() {
 	}
 	log.SetOutput(io.MultiWriter(os.Stdout, f))
 
-	r := router.New(orderCtrl, itemCtrl, basketCtrl, secret, authCtrl, userCtrl)
+	r := router.New(orderCtrl, itemCtrl, basketCtrl, secret, authCtrl, userCtrl, rbacCtrl)
 	log.Println("server listening on :8089")
 	log.Fatal(http.ListenAndServe(":8089", r))
 }

--- a/docs/order-swagger.yaml
+++ b/docs/order-swagger.yaml
@@ -60,3 +60,8 @@ paths:
       summary: Service metrics
       responses:
         '200': {description: OK}
+  /allowed-endpoints:
+    get:
+      summary: List allowed endpoints for current user
+      responses:
+        '200': {description: OK}

--- a/internal/rbac/controller.go
+++ b/internal/rbac/controller.go
@@ -1,0 +1,26 @@
+package rbac
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"order/internal/auth"
+)
+
+// Controller exposes RBAC related handlers.
+type Controller struct{}
+
+func NewController() *Controller { return &Controller{} }
+
+// AllowedEndpoints returns a list of endpoints accessible by the current user.
+func (c *Controller) AllowedEndpoints(w http.ResponseWriter, r *http.Request) {
+	roles := auth.RolesFromContext(r.Context())
+	eps := AllowedEndpointsForRoles(roles)
+	respondJSON(w, http.StatusOK, eps)
+}
+
+func respondJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -1,0 +1,144 @@
+package rbac
+
+import (
+	"order/internal/user"
+)
+
+// Permission represents an action that can be performed on a resource.
+type Permission string
+
+const (
+	PermissionViewOrders     Permission = "orders:view"
+	PermissionEditOrders     Permission = "orders:edit"
+	PermissionViewItems      Permission = "items:view"
+	PermissionEditItems      Permission = "items:edit"
+	PermissionViewBaskets    Permission = "baskets:view"
+	PermissionEditBaskets    Permission = "baskets:edit"
+	PermissionViewPayments   Permission = "payments:view"
+	PermissionEditPayments   Permission = "payments:edit"
+	PermissionViewDeliveries Permission = "deliveries:view"
+	PermissionEditDeliveries Permission = "deliveries:edit"
+	PermissionCreateUsers    Permission = "users:create"
+)
+
+// Endpoint describes an HTTP endpoint that requires a permission.
+type Endpoint struct {
+	Method     string `json:"method"`
+	Path       string `json:"path"`
+	Permission string `json:"permission"`
+}
+
+var rolePermissions = map[user.Role][]Permission{
+	user.RoleAdmin: {
+		PermissionViewOrders, PermissionEditOrders,
+		PermissionViewItems, PermissionEditItems,
+		PermissionViewBaskets, PermissionEditBaskets,
+		PermissionViewPayments, PermissionEditPayments,
+		PermissionViewDeliveries, PermissionEditDeliveries,
+		PermissionCreateUsers,
+	},
+	user.RoleSupportManager: {
+		PermissionViewOrders, PermissionEditOrders,
+		PermissionViewItems, PermissionEditItems,
+		PermissionViewBaskets, PermissionEditBaskets,
+		PermissionViewPayments, PermissionEditPayments,
+		PermissionViewDeliveries, PermissionEditDeliveries,
+		PermissionCreateUsers,
+	},
+	user.RoleSeller: {
+		PermissionViewOrders, PermissionEditOrders,
+		PermissionViewItems,
+		PermissionViewBaskets, PermissionEditBaskets,
+	},
+	user.RoleCustomer: {
+		PermissionViewOrders,
+		PermissionViewBaskets,
+	},
+	user.RoleLogisticsManager: {
+		PermissionViewDeliveries, PermissionEditDeliveries,
+	},
+	user.RolePaymentManager: {
+		PermissionViewPayments, PermissionEditPayments,
+	},
+	user.RoleAuditor: {
+		PermissionViewOrders,
+	},
+}
+
+var permissionEndpoints = map[Permission][]Endpoint{
+	PermissionViewOrders: {
+		{Method: "GET", Path: "/orders", Permission: string(PermissionViewOrders)},
+		{Method: "GET", Path: "/orders/{id}", Permission: string(PermissionViewOrders)},
+	},
+	PermissionEditOrders: {
+		{Method: "POST", Path: "/orders", Permission: string(PermissionEditOrders)},
+		{Method: "PATCH", Path: "/orders/{id}", Permission: string(PermissionEditOrders)},
+		{Method: "DELETE", Path: "/orders/{id}", Permission: string(PermissionEditOrders)},
+	},
+	PermissionViewItems: {
+		{Method: "GET", Path: "/items", Permission: string(PermissionViewItems)},
+		{Method: "GET", Path: "/items/{id}", Permission: string(PermissionViewItems)},
+	},
+	PermissionEditItems: {
+		{Method: "POST", Path: "/items", Permission: string(PermissionEditItems)},
+		{Method: "PATCH", Path: "/items/{id}", Permission: string(PermissionEditItems)},
+		{Method: "DELETE", Path: "/items/{id}", Permission: string(PermissionEditItems)},
+	},
+	PermissionViewBaskets: {
+		{Method: "GET", Path: "/baskets", Permission: string(PermissionViewBaskets)},
+		{Method: "GET", Path: "/baskets/{id}", Permission: string(PermissionViewBaskets)},
+		{Method: "GET", Path: "/baskets/{id}/items", Permission: string(PermissionViewBaskets)},
+	},
+	PermissionEditBaskets: {
+		{Method: "POST", Path: "/baskets", Permission: string(PermissionEditBaskets)},
+		{Method: "PATCH", Path: "/baskets/{id}", Permission: string(PermissionEditBaskets)},
+		{Method: "DELETE", Path: "/baskets/{id}", Permission: string(PermissionEditBaskets)},
+		{Method: "POST", Path: "/baskets/{id}/items", Permission: string(PermissionEditBaskets)},
+		{Method: "PATCH", Path: "/baskets/{id}/items/{item_id}", Permission: string(PermissionEditBaskets)},
+		{Method: "DELETE", Path: "/baskets/{id}/items/{item_id}", Permission: string(PermissionEditBaskets)},
+	},
+	PermissionViewPayments: {
+		{Method: "GET", Path: "/payments/{id}", Permission: string(PermissionViewPayments)},
+	},
+	PermissionEditPayments: {
+		{Method: "POST", Path: "/payments", Permission: string(PermissionEditPayments)},
+	},
+	PermissionViewDeliveries: {
+		{Method: "GET", Path: "/deliveries", Permission: string(PermissionViewDeliveries)},
+		{Method: "GET", Path: "/deliveries/{id}", Permission: string(PermissionViewDeliveries)},
+		{Method: "GET", Path: "/locations/{provider}", Permission: string(PermissionViewDeliveries)},
+	},
+	PermissionEditDeliveries: {
+		{Method: "POST", Path: "/deliveries", Permission: string(PermissionEditDeliveries)},
+		{Method: "PATCH", Path: "/deliveries/{id}", Permission: string(PermissionEditDeliveries)},
+		{Method: "DELETE", Path: "/deliveries/{id}", Permission: string(PermissionEditDeliveries)},
+	},
+	PermissionCreateUsers: {
+		{Method: "POST", Path: "/users", Permission: string(PermissionCreateUsers)},
+	},
+}
+
+// AllowedEndpointsForRoles returns allowed endpoints for the specified roles.
+func AllowedEndpointsForRoles(roles []string) []Endpoint {
+	permSet := map[Permission]struct{}{}
+	for _, r := range roles {
+		role := user.Role(r)
+		if perms, ok := rolePermissions[role]; ok {
+			for _, p := range perms {
+				permSet[p] = struct{}{}
+			}
+		}
+	}
+	endpMap := map[string]Endpoint{}
+	for p := range permSet {
+		for _, e := range permissionEndpoints[p] {
+			key := e.Method + " " + e.Path
+			endpMap[key] = e
+		}
+	}
+	result := make([]Endpoint, 0, len(endpMap))
+	for _, e := range endpMap {
+		result = append(result, e)
+	}
+	return result
+}

--- a/internal/rbac/rbac_test.go
+++ b/internal/rbac/rbac_test.go
@@ -1,0 +1,23 @@
+package rbac
+
+import (
+	"testing"
+)
+
+func TestAllowedEndpointsForRoles(t *testing.T) {
+	eps := AllowedEndpointsForRoles([]string{"admin"})
+	if len(eps) == 0 {
+		t.Fatalf("no endpoints returned")
+	}
+	// expect one known endpoint
+	found := false
+	for _, e := range eps {
+		if e.Method == "GET" && e.Path == "/orders" && e.Permission == string(PermissionViewOrders) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected orders GET endpoint for admin")
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -12,11 +12,12 @@ import (
 	"order/internal/item"
 	"order/internal/metrics"
 	ord "order/internal/order"
+	"order/internal/rbac"
 	usr "order/internal/user"
 )
 
 // New sets up application routes with middleware
-func New(orderCtrl *ord.Controller, itemCtrl *item.Controller, basketCtrl *basket.Controller, secret []byte, authCtrl *auth.Controller, userCtrl *usr.Controller) http.Handler {
+func New(orderCtrl *ord.Controller, itemCtrl *item.Controller, basketCtrl *basket.Controller, secret []byte, authCtrl *auth.Controller, userCtrl *usr.Controller, rbacCtrl *rbac.Controller) http.Handler {
 	r := mux.NewRouter()
 
 	r.Use(metrics.Middleware)
@@ -34,6 +35,7 @@ func New(orderCtrl *ord.Controller, itemCtrl *item.Controller, basketCtrl *baske
 	itemCtrl.RegisterRoutes(api)
 	basketCtrl.RegisterRoutes(api)
 	api.HandleFunc("/users", userCtrl.CreateUser).Methods("POST")
+	api.HandleFunc("/allowed-endpoints", rbacCtrl.AllowedEndpoints).Methods("GET")
 
 	return r
 }

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -11,6 +11,7 @@ import (
 	"order/internal/basket"
 	"order/internal/item"
 	ord "order/internal/order"
+	"order/internal/rbac"
 	usr "order/internal/user"
 )
 
@@ -59,15 +60,6 @@ func (m *memUserRepo) GetByUsername(_ context.Context, _ string) (*usr.User, err
 }
 func (m *memUserRepo) Update(_ context.Context, _ *usr.User) error { return nil }
 
-// memUserRepo is a simple in-memory user repository.
-type memUserRepo struct{ user *usr.User }
-
-func (m *memUserRepo) Create(_ context.Context, u *usr.User) error { m.user = u; return nil }
-func (m *memUserRepo) GetByUsername(_ context.Context, _ string) (*usr.User, error) {
-	return m.user, nil
-}
-func (m *memUserRepo) Update(_ context.Context, _ *usr.User) error { return nil }
-
 func TestCreateOrderStatusCode(t *testing.T) {
 	repo := newMockRepo()
 	svc := ord.NewService(repo)
@@ -84,7 +76,7 @@ func TestCreateOrderStatusCode(t *testing.T) {
 	authCtrl := auth.NewController(authSvc, userSvc)
 	userCtrl := usr.NewController(userSvc)
 
-	r := New(ctrl, itemCtrl, basketCtrl, secret, authCtrl, userCtrl)
+	r := New(ctrl, itemCtrl, basketCtrl, secret, authCtrl, userCtrl, rbac.NewController())
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 


### PR DESCRIPTION
## Summary
- add RBAC package to calculate permissions
- expose a new `/allowed-endpoints` endpoint
- document the endpoint in OpenAPI spec
- update router and server wiring
- add tests for RBAC permission logic

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685d4a5cdad483249771afd38285d09b